### PR TITLE
Add pod priority support for cray-service base chart

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.8.0]
+### Added
+- New options added to support pod priorities for postgres clusters, deployments, statefulsets and daemonsets.
+
 ## [2.7.0]
 ### Added
 - New options are added to enable an automatic backup of the PostgreSQL database. Users must opt-in.

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 name: cray-service
 home: "cloud/cray-charts"
-version: 2.7.0
+version: 2.8.0

--- a/kubernetes/cray-service/templates/_common-spec.tpl
+++ b/kubernetes/cray-service/templates/_common-spec.tpl
@@ -11,6 +11,9 @@ serviceAccountName: "{{ .Values.serviceAccountName }}"
 {{- else if or (.Values.sqlCluster.enabled) (.Values.etcdCluster.enabled) }}
 serviceAccountName: "jobs-watcher"
 {{- end }}
+{{- if .Values.priorityClassName }}
+priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
 {{- $initContainersLength := len .Values.initContainers -}}
 {{- if or (gt $initContainersLength 0) (or .Values.sqlCluster.enabled (or .Values.etcdCluster.enabled .Values.kafkaCluster.enabled)) }}
 initContainers:

--- a/kubernetes/cray-service/templates/postgresql.yaml
+++ b/kubernetes/cray-service/templates/postgresql.yaml
@@ -44,6 +44,9 @@ spec:
   volume:
     size: {{ .Values.sqlCluster.volumeSize }}
   numberOfInstances: {{ .Values.sqlCluster.instanceCount }}
+{{- if .Values.sqlCluster.podPriorityClassName }}
+  podPriorityClassName: {{ .Values.sqlCluster.podPriorityClassName }}
+{{- end }}
   {{- if .Values.sqlCluster.resources }}
   {{- with .Values.sqlCluster.resources }}
   resources:

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -13,6 +13,10 @@ nameOverride: "" # the name of your service
 fullnameOverride: "" # use this if you want to provide a more-complete name for certain labels/naming (very optional)
 replicaCount: 1
 partitionId: ""
+#
+# Use the following setting to add pod priority to your Deployment|StatefulSet|DaemonSet
+#
+# priorityClassName: csm-high-priority-service
 # custom pod hostname
 hostname: ""
 # the below are labels/annotations to generically apply to metadata on resources.
@@ -183,6 +187,10 @@ sqlCluster:
   instanceCount: 3
   postgresVersion: "11"
   volumeSize: 1Gi
+  #
+  # Consumers of this chart can set pod priority for postgres pods as follows:
+  #
+  # podPriorityClassName: csm-high-priority-service
   users:
     service_account: []
   databases:


### PR DESCRIPTION
### Summary and Scope

Add pod priority support to cray-service for postgres clusters, deployments, statefulsets and daemonsets.

### Issues and Related PRs

* CASMPET-4416

### Testing

* helm

Used gitea as guinea pig with new cray-service:

```
diff --git a/kubernetes/gitea/values.yaml b/kubernetes/gitea/values.yaml
index 17ab9e6..b740daf 100644
--- a/kubernetes/gitea/values.yaml
+++ b/kubernetes/gitea/values.yaml
@@ -14,11 +14,12 @@ global:

 cray-service:
   storageClass: ceph-cephfs-external
-  type: Deployment
+  type: DaemonSet
   strategy:
     type: Recreate
     rollingUpdate: null
   nameOverride: vcs
+  priorityClassName: csm-high-priority-service
   containers:
     vcs:
       name: vcs
@@ -111,6 +112,7 @@ cray-service:
     instanceCount: 3
     postgresVersion: "11"
     volumeSize: 50Gi
+    podPriorityClassName: csm-high-priority-service
     users:
       service_account: []
     databases:
```

```
C02YT3JRLVCJ:gitea bklein$ helm template . | grep -i  priority
      priorityClassName: csm-high-priority-service
  podPriorityClassName: csm-high-priority-service
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Fresh install
