### PR TITLE
CASMPET-4404:  Support multiple gateways

### DIFF
--- a/kubernetes/cray-service/templates/ingress.yaml
+++ b/kubernetes/cray-service/templates/ingress.yaml
@@ -21,8 +21,10 @@ metadata:
 spec:
   hosts:
     - "*"
+  {{- with .Values.ingress.gateways }}
   gateways:
-    - {{ .Values.ingress.gateway }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   http:
     - match:
         - uri:

--- a/kubernetes/cray-service/tests/deployment-ingress_test.yaml
+++ b/kubernetes/cray-service/tests/deployment-ingress_test.yaml
@@ -40,3 +40,31 @@ tests:
       - matchRegex:
           path: spec.http[0].match[0].uri.regex
           pattern: ^/.*\/?$
+  - it: should render the default gateways
+    set:
+      ingress.enabled: true
+    asserts:
+      - template: ingress.yaml
+        equal:
+          path: spec.gateways[0]
+          value: services-gateway
+      - template: ingress.yaml
+        equal:
+          path: spec.gateways[1]
+          value: customer-admin-gateway
+  - it: should render the overridden gateways
+    set:
+      ingress.enabled: true
+      ingress.gateways:
+          - testgateway1
+          - testgateway2
+    asserts:
+      - template: ingress.yaml
+        equal:
+          path: spec.gateways[0]
+          value: testgateway1
+      - template: ingress.yaml
+        equal:
+          path: spec.gateways[1]
+          value: testgateway2
+

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -163,7 +163,9 @@ ingress:
   ui: false # TODO: we're not actually doing anything with this yet, but should be applicable for istio auth decisions
   # ingress.gateway
   # This should never really be changed unless you know what you're doing.
-  gateway: "services-gateway"
+  gateways:
+    - "services-gateway"
+    - "customer-admin-gateway"
   # ingress.prefix
   # This is the route to your service through the gateway from the outside. It defaults to /apis/{service name minus any `cray-`}
   # Example: `cray-ims` would default to `/apis/ims` if prefix == ""


### PR DESCRIPTION
This adds support for more than one gateway in the cray-service chart.   It currently defaults to using services-gateway and cmn-services-gateway.

Tested this with the cray-sts chart on vshasta.   Verified that Virtual Services has the expected gateways specified.