### PR TITLE
CASMPET-4681: Default base-service securityContext to run as nobody

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ These charts are used as subcharts by other charts.
 
 ## Testing charts here and elsewhere
 
-Please see the [cray-chartsutil](https://stash.us.cray.com/projects/CLOUD/repos/cray-chartsutil/browse) for more info on testing out charts.
+Run `make chart1_test` / `make chart2_test` to run the tests.

--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Changed
+- The default container securityContext now sets runAsUser, runAsGroup, and runAsNonRoot.
 
 ## [3.0.0]
 ### Changed

--- a/kubernetes/cray-service/templates/_common-container.tpl
+++ b/kubernetes/cray-service/templates/_common-container.tpl
@@ -1,6 +1,25 @@
 {{/*
 A common container spec for use in both containers and initContainers
 Note that despite that it may look as though
+
+MIT License
+(C) Copyright [2020-2021] Hewlett Packard Enterprise Development LP
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
 */}}
 {{- define "cray-service.common-container" }}
 - name: {{ .Container.name }}
@@ -92,6 +111,11 @@ Note that despite that it may look as though
   {{- if .Container.securityContext }}
   securityContext:
     {{- toYaml .Container.securityContext | nindent 4 -}}
+  {{- else }}
+  securityContext:
+    runAsUser: {{ .Root.Values.nobodyUserId }}
+    runAsGroup: {{ .Root.Values.nobodyGroupId }}
+    runAsNonRoot: true
   {{- end -}}
   {{- if .Container.stdin }}
   stdin: {{ .Container.stdin }}

--- a/kubernetes/cray-service/tests/deployment-all-container-fields_test.yaml
+++ b/kubernetes/cray-service/tests/deployment-all-container-fields_test.yaml
@@ -1,3 +1,22 @@
+
+# MIT License
+# (C) Copyright [2020-2021] Hewlett Packard Enterprise Development LP
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
 ---
 suite: deployment all container fields test
 templates:
@@ -189,7 +208,26 @@ tests:
         equal:
           path: spec.template.spec.containers[0].resources.requests.memory
           value: "64Mi"
-  - it: should render the correct security context
+  - it: should render the default security context
+    set:
+      containers:
+        - name: test-service
+          image:
+            repository: test-service
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 65534
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 65534
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+  - it: should render the overridden security context
     set:
       containers:
         - name: test-service
@@ -202,6 +240,19 @@ tests:
         equal:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false
+      # The default values aren't rendered.
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: null
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: null
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: null
   - it: should render the correct stdin values, termination message path, tty, and workingDir
     set:
       containers:

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -3,6 +3,24 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# MIT License
+# (C) Copyright [2020-2021] Hewlett Packard Enterprise Development LP
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
 imagesHost: "dtr.dev.cray.com" # this value will always be set on helm install based on install context, this is a reasonable default
 imagePullSecrets: []
 storageClass: "" # intended to be set/overriden at install time, or not set at all to use the default
@@ -36,6 +54,9 @@ tolerations: []
 affinity: {}
 serviceAccountName: "" # if set, not empty, will set the service account to use for the deployment/statefulset, daemonset, etc.
 
+nobodyUserId: 65534 # The nobody user ID on our systems.
+nobodyGroupId: 65534 # The nobody group ID on our systems.
+
 # Deployment Upgrade Strategy
 # Only relevant if type: Deployment is set
 # This is the standard K8S DeploymentStrategy object
@@ -61,21 +82,25 @@ containers: {}
 #     repository: "" # e.g. cray/my-service
 #     tag: latest
 #     pullPolicy: IfNotPresent
+#   securityContext:
+#     runAsUser: 65534
+#     runAsGroup: 65534
+#     runAsNonRoot: true
 #   env: []
 #   ports:
 #     - name: http
-#       containerPort: 80
+#       containerPort: 8080
 #       protocol: TCP
 #   livenessProbe:
 #     httpGet:
 #       path: /
-#       port: 80
+#       port: 8080
 #     initialDelaySeconds: 5
 #     periodSeconds: 3
 #   readinessProbe:
 #     httpGet:
 #       path: /
-#       port: 80
+#       port: 8080
 #     initialDelaySeconds: 5
 #     periodSeconds: 3
 #   ... other standard k8s container properties supported: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#container-v1-core


### PR DESCRIPTION
### Summary and Scope

The current default for the base-service chart securityContext for
containers is unset. This is changing to

```
  securityContext:
    runAsUser: {{ .Values.nobodyUserId }}
    runAsGroup: {{ .Values.nobodyGroupId }}
    runAsNonRoot: true
```

Users of the base-service chart that need something different can
override this.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? Neither

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-4681

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Applied this change to a chart (cray-capmc) and deployed it. Made sure that the Pod has the new securityContext.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

Requires: None
