### PR TITLE
CASMPET-4681: Bump cray-service to prep for release

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
+## [4.0.0]
 ### Changed
 - The default container securityContext now sets runAsUser, runAsGroup, and runAsNonRoot.
 

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 name: cray-service
 home: "cloud/cray-charts"
-version: 3.0.0
+version: 4.0.0


### PR DESCRIPTION
This includes

* CASMPET-4681: Default base-service securityContext to run as nobody

The change isn't backwards compatible so need to bump the major
number.