### PR TITLE
CASMPET-4864: wait-for-progress run as nobody

### DIFF
--- a/kubernetes/cray-service/templates/postgresql.yaml
+++ b/kubernetes/cray-service/templates/postgresql.yaml
@@ -146,6 +146,10 @@ spec:
         {{- $user := index $root.Values.sqlCluster.databases $database }}
         - name: "postgres-watcher-{{ $database | replace "_" "-" }}"
           image: "{{ include "cray-service.image-prefix" $root.Values }}cache/postgres:13.2"
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
           command: ["sh", "-c", "until psql postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB -c 'select version();'; do echo waiting for postgres db $POSTGRES_DB; sleep 2; done;  echo 'POSTGRES_READY';"]
           env:
           - name: POSTGRES_USER


### PR DESCRIPTION

### Summary and Scope

The wait-for-postgres Job that's started by the cray-service base
chart when postgres is enabled can and should run as the `nobody`
user. This is to prevent a breakout from having authority on the
host.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? New Feature

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-4864

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? N   If not, Why? Tested upgrade/downgrade and already tested similar change with keycloak.
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed cray-hms-sls with this chart and made sure the Job ran, checked the Job had the updated securityContext. Rolled back and made sure the securityContext was removed from the Job.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? None

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

Requires: None
