### PR TITLE
CASMPET-4864: wait-for-progress run as nobody

### DIFF
--- a/kubernetes/cray-service/templates/postgresql.yaml
+++ b/kubernetes/cray-service/templates/postgresql.yaml
@@ -146,6 +146,10 @@ spec:
         {{- $user := index $root.Values.sqlCluster.databases $database }}
         - name: "postgres-watcher-{{ $database | replace "_" "-" }}"
           image: "{{ include "cray-service.image-prefix" $root.Values }}cache/postgres:13.2"
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
           command: ["sh", "-c", "until psql postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB -c 'select version();'; do echo waiting for postgres db $POSTGRES_DB; sleep 2; done;  echo 'POSTGRES_READY';"]
           env:
           - name: POSTGRES_USER


### PR DESCRIPTION
The wait-for-postgres Job that's started by the cray-service base
chart when postgres is enabled can and should run as the `nobody`
user. This is to prevent a breakout from having authority on the
host.

(cherry picked from commit 1f2ce5a95fccf8a63f4d04d9e386aacc414afab5)