### PR TITLE
CASMPET-4920: Bump version to 5.0.0 (1.1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,22 @@
 See the CASM PET team's [contributing guide](https://connect.us.cray.com/confluence/display/CASMPET/CONTRIBUTING).
+
+# When making changes
+
+Please update the CHANGELOG.md: https://keepachangelog.com/en/1.0.0/
+
+# When releasing
+
+Picking the version:
+- if this is the first release targeting a new version of CSM,
+  increase the MAJOR version regardless of what semver says to do.
+- if this is for an older released of CSM,
+  never increase the MAJOR version regardless of what semver says to do.
+- Otherwise just follow semver as normal.
+
+Update the CHANGELOG.md: https://keepachangelog.com/en/1.0.0/
+
+Update the PET wiki page with the current version number:
+https://connect.us.cray.com/confluence/display/CASMPET/Base+Charts+by+Release
+
+You'll probably want to send out an announcement telling consumers to pick up a new version:
+https://connect.us.cray.com/confluence/display/CASMPET/Announcements

--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [5.0.0]
+There were no changes from 2.8.2 and also this is the same as 2.8.0.
+
 ## [2.8.2]
 ### Changed
 - Reverted the change to the default securityContext.

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 name: cray-service
 home: "cloud/cray-charts"
-version: 2.8.2
+version: 5.0.0


### PR DESCRIPTION
The old versioning scheme incremented the MINOR version when the first
release was made targeting a new version of CSM. This caused a problem
because consumers of the chart were setting the requirement to pick up
any new chart with the same MAJOR version. This caused a bunch of
charts to pick up CSM-1.1 content when they were rebuilt for CSM-1.0.
The new versioning scheme will change the MAJOR version for new CSM
releases. This commit brings the cray-service chart into alignment with
the new scheme.

The version is 5.0 because there's already a 3.0 & 4.0 for CSM-1.2;
the version in CSM-1.2 is being updated to 6.0.

(cherry picked from commit 27ac47a4bc85d9d59fbeac6ec237cfbab27f1df6)