### PR TITLE
CASMPET-4939: Update reference to chart repository

### DIFF
--- a/kubernetes/cray-jobs/README.md
+++ b/kubernetes/cray-jobs/README.md
@@ -11,7 +11,7 @@ In your Helm chart, just add it to the `requirements.yaml` like:
 dependencies:
   - name: cray-jobs
     version: "~0.1.0-0"
-    repository: "@cray-internal"
+    repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
 ```
 
 You can then add the relevant part to your chart's `values.yaml`, something like:


### PR DESCRIPTION
The old DST @cray-internal chart repository is going away and
users of the cray-jobs chart should be using algol60 artifactory
now.