### PR TITLE
CASM-2670: Refactor to use patched CSM images

### DIFF
--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: cray-service
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: "cloud/cray-charts"

--- a/kubernetes/cray-service/templates/_common-wait_for_job_container.tpl
+++ b/kubernetes/cray-service/templates/_common-wait_for_job_container.tpl
@@ -3,7 +3,7 @@ An InitContainer spec that waits for job completion
 */}}
 {{- define "cray-service.common-wait-for-job-container" }}
 - name: "{{.JobName }}"
-  image: "{{ include "cray-service.image-prefix" .Root.Values }}loftsman/docker-kubectl:0.2.0"
+  image: "{{ include "kubectl.image" .Root.Values }}"
   command: 
     - /bin/sh
     - -c

--- a/kubernetes/cray-service/templates/_helpers.tpl
+++ b/kubernetes/cray-service/templates/_helpers.tpl
@@ -100,3 +100,10 @@ Create the name of the service account to use for the postgres DB Backup
     {{ default "default" .Values.sqlCluster.backup.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create image names and version as used by the chart
+*/}}
+{{- define "kubectl.image" -}}
+{{- printf "%s:%s" .kubectl.image | trunc 63 | trimSuffix ":" -}}
+{{- end -}}

--- a/kubernetes/cray-service/templates/postgresql.yaml
+++ b/kubernetes/cray-service/templates/postgresql.yaml
@@ -145,7 +145,7 @@ spec:
         {{- $database := . }}
         {{- $user := index $root.Values.sqlCluster.databases $database }}
         - name: "postgres-watcher-{{ $database | replace "_" "-" }}"
-          image: "{{ include "cray-service.image-prefix" $root.Values }}cache/postgres:13.2"
+          image: "artifactory.algol60.net/csm-docker/stable/docker.io/library/postgres:13.2-alpine"
           securityContext:
             runAsUser: 65534
             runAsGroup: 65534
@@ -226,7 +226,7 @@ spec:
         {{- $database := . }}
         {{- $user := index $root.Values.sqlCluster.databases $database }}
         - name: "postgres-create-pooler-schema-{{ $database | replace "_" "-" }}"
-          image: "{{ include "cray-service.image-prefix" $root.Values }}cache/postgres:13.2"
+          image: "artifactory.algol60.net/csm-docker/stable/docker.io/library/postgres:13.2-alpine"
           command: ["sh", "-c", "until psql postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB -c 'select version();'; do echo waiting for postgres db $POSTGRES_DB; sleep 2; done; sleep 60;psql postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB -f /scripts/pooler-schema.sql"]
           env:
             - name: POSTGRES_USER

--- a/kubernetes/cray-service/tests/deployment-etcd-enabled_test.yaml
+++ b/kubernetes/cray-service/tests/deployment-etcd-enabled_test.yaml
@@ -44,7 +44,6 @@ tests:
     set:
       etcdCluster.enabled: true
       chart.name: "test-chart"
-      imagesHost: "my-repo"
     asserts:
       - template: deployment.yaml
         equal:
@@ -53,7 +52,7 @@ tests:
       - template: deployment.yaml
         equal:
           path: spec.template.spec.initContainers[0].image
-          value: "my-repo/loftsman/docker-kubectl:0.2.0"
+          value: "artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.9"
       - template: deployment.yaml
         equal:
           path: spec.template.spec.serviceAccountName

--- a/kubernetes/cray-service/tests/deployment-sql-enabled_test.yaml
+++ b/kubernetes/cray-service/tests/deployment-sql-enabled_test.yaml
@@ -275,7 +275,6 @@ tests:
     set:
       sqlCluster.enabled: true
       chart.name: "test-chart"
-      imagesHost: "my-repo"
       containers:
         test-service:
           name: test-service
@@ -289,7 +288,7 @@ tests:
       - template: deployment.yaml
         equal:
           path: spec.template.spec.initContainers[0].image
-          value: "my-repo/loftsman/docker-kubectl:0.2.0"
+          value: "artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.9"
       - template: deployment.yaml
         equal:
           path: spec.template.spec.serviceAccountName
@@ -373,4 +372,4 @@ tests:
           value: session
         equal:
           path: spec.connectionPooler.dockerImage
-          value: "dtr.dev.cray.com/acid/pgbouncer:master-17"
+          value: "artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-17"

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -21,7 +21,9 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-imagesHost: "dtr.dev.cray.com" # this value will always be set on helm install based on install context, this is a reasonable default
+kubectl:
+  image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.9
+
 imagePullSecrets: []
 storageClass: "" # intended to be set/overriden at install time, or not set at all to use the default
 
@@ -239,7 +241,7 @@ sqlCluster:
     enabled: false
     instanceCount: 3
     mode: "session"
-    image: "dtr.dev.cray.com/acid/pgbouncer:master-17"
+    image: "artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-17"
   #
   # Consumers of this chart can override postgres cluster pod resource limits as follows:
   #
@@ -263,7 +265,7 @@ sqlCluster:
   backup:
     enabled: false
     image:
-      repository: "dtr.dev.cray.com/cray/cray-postgres-db-backup"
+      repository: "artifactory.algol60.net/csm-docker/stable/postgres-db-backup"
       pullPolicy: IfNotPresent
       tag: "0.1.0"
 


### PR DESCRIPTION
This PR is intended to update images and solved the CASMPET-5037 (cray-postgres-operator)

- Update images from host dtr to algol60
- CASM-2670: Refactor to use patched CSM images

See: https://connect.us.cray.com/jira/browse/CASMPET-5037