### PR TITLE
EtcdCluster spec.repository does not include a tag

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [7.0.01]
+### Changed
+- cray-service renders EtcdCluster `spec.repository` values without tags
+
 ## [7.0.0]
 ### Changed
 - Updated chart to apiVersion v2 and refactored image references to remove dtr.dev.cray.com

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-service
-version: 7.0.0
+version: 7.0.1
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:

--- a/kubernetes/cray-service/templates/etcd-cluster.yaml
+++ b/kubernetes/cray-service/templates/etcd-cluster.yaml
@@ -28,7 +28,7 @@ spec:
       operatorSecret: "{{ include "cray-service.fullname" . }}-etcd-client-tls"
   {{- end }}
   version: {{ trimPrefix "v" .Values.etcdCluster.image.tag }}
-  repository: {{ .Values.etcdCluster.image.repository }}:{{ .Values.etcdCluster.image.tag }}
+  repository: {{ .Values.etcdCluster.image.repository }}
   pod:
     busyboxImage: {{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}
 {{- if .Values.etcdCluster.podPriorityClassName }}


### PR DESCRIPTION
Backport of #32 to cray-service-7.0.