### PR TITLE
Fixes CASMPET-5202: update pgbouncer to the latest from upstream

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [8.1.0]
+### Changed
+- Updated pgbouncer image version to the latest from upstream
+
 ## [8.0.0]
 ### Changed
 - Added the ability to specify multiple TRSWorker resources.

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-service
-version: 8.0.0
+version: 8.1.0
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:
@@ -18,7 +18,7 @@ annotations:
     - name: postgres
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/postgres:13.2-alpine
     - name: acid/pgbouncer
-      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-17
+      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-19
     - name: cray-postgres-db-backup
       image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.0
   artifacthub.io/license: MIT

--- a/kubernetes/cray-service/tests/deployment-sql-enabled_test.yaml
+++ b/kubernetes/cray-service/tests/deployment-sql-enabled_test.yaml
@@ -372,7 +372,7 @@ tests:
     set:
       sqlCluster.enabled: true
       sqlCluster.connectionPooler.enabled: true
-      sqlCluster.connectionPooler.image: pgbouncer:master-17
+      sqlCluster.connectionPooler.image: pgbouncer:master-19
     asserts:
       - template: postgresql.yaml
         documentIndex: 0
@@ -393,4 +393,4 @@ tests:
         documentIndex: 0
         equal:
           path: spec.connectionPooler.dockerImage
-          value: pgbouncer:master-17
+          value: pgbouncer:master-19

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -258,7 +258,7 @@ sqlCluster:
     enabled: false
     instanceCount: 3
     mode: "session"
-    image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-17
+    image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-19
   #
   # Consumers of this chart can override postgres cluster pod resource limits as follows:
   #


### PR DESCRIPTION
## Summary and Scope

Update pgbouncer with the latest master-19 release from upstream. The latest image has 0 critical and 
1 high CVE (an improvement from 2 critical and 3 high CVEs in master-17 image we're currently using).
Chart minor version is increased from 8.0.0 to 8.1.0 as it's a minor release upgrade for pgbouncer.

## Issues and Related PRs

* Resolves [CASMPET-5202]

## Testing

### Tested on:

  * `wasp`

### Test description:

Tested the new chart with cray-spire chart on wasp, and verified that the spire-postgres-pooler pods
successfully pulled the latest pgbouncer image. Pod logs showed no errors after being up for more 
than 30 minutes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. It's a minor version upgrade for pgbouncer, and is only used by spire-postgres-pooler pods.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

