### PR TITLE
CASMINST-4082: update pgbouncer to the latest from upstream

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [8.1.2]
+### Changed
+- Updated pgbouncer image version to the latest (master-21) built from upstream
+
 ## [8.1.1]
 ### Changed
 - The default tag for the cray-postgres-db-backup is now 0.2.1 to pick up security fixes.

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 8.1.1
+version: 8.1.2
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:
@@ -40,7 +40,7 @@ annotations:
     - name: postgres
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/postgres:13.2-alpine
     - name: acid/pgbouncer
-      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-19
+      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-21
     - name: cray-postgres-db-backup
       image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.1
   artifacthub.io/license: MIT

--- a/kubernetes/cray-service/tests/deployment-sql-enabled_test.yaml
+++ b/kubernetes/cray-service/tests/deployment-sql-enabled_test.yaml
@@ -395,7 +395,7 @@ tests:
     set:
       sqlCluster.enabled: true
       sqlCluster.connectionPooler.enabled: true
-      sqlCluster.connectionPooler.image: pgbouncer:master-19
+      sqlCluster.connectionPooler.image: pgbouncer:master-21
     asserts:
       - template: postgresql.yaml
         documentIndex: 0
@@ -416,4 +416,4 @@ tests:
         documentIndex: 0
         equal:
           path: spec.connectionPooler.dockerImage
-          value: pgbouncer:master-19
+          value: pgbouncer:master-21

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -281,7 +281,7 @@ sqlCluster:
     enabled: false
     instanceCount: 3
     mode: "session"
-    image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-19
+    image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-21
   #
   # Consumers of this chart can override postgres cluster pod resource limits as follows:
   #


### PR DESCRIPTION
## Summary and Scope

Use pgbouncer master-21 docker image. The master-19 docker image we currently use is based on alpine 3.12.8, with 0 critical and 10 high CVEs. The new master-21 docker image is based on alpine 3.12.9, with 0 critical and only 1 high CVE.

## Issues and Related PRs

* Resolves [CASMINST-4082]

## Testing

Will be tested with a new cray-spire chart PR on a bare metal system or vshasta.

## Risks and Mitigations

Low. This is minor release update.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

