### PR TITLE
CASMINST-4214 Enable external tls in postgresql

### DIFF
--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 8.1.2
+version: 8.1.3
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -217,7 +217,7 @@ etcdCluster:
     accessMode: "ReadWriteOnce"
     storage: 3Gi  # A bit of headroom above 2GB quota default
   tls:
-    enabled: false
+    enabled: true
     issuer: cert-manager-issuer-common
   #
   # Consumers of this chart can set pod priority for etcd pods as follows:


### PR DESCRIPTION
## Summary and Scope

This re-enabled the external TLS certification for postgresql. Disabling it was breaking upgrades when postgresq instances get moved from using it, to using an internal cert. This appears to be a kubernetes bug and not related to our chart.

## Issues and Related PRs


* Resolves [CASMINST-4214](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4214) 

## Testing

No testing is needed, as this is enabling an option that has already been tested.

## Risks and Mitigations

Charts that use cray-services will need to be bumped and made sure that they pull in this new 8.1.3 version.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

