### PR TITLE
CASMPET-5690 master : cray-services: ~8 missing change made to 7.0.1 for etcd image tag

### DIFF
--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 8.1.3
+version: 9.0.0
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:

--- a/kubernetes/cray-service/templates/etcd-cluster.yaml
+++ b/kubernetes/cray-service/templates/etcd-cluster.yaml
@@ -51,7 +51,7 @@ spec:
       operatorSecret: "{{ include "cray-service.fullname" . }}-etcd-client-tls"
   {{- end }}
   version: {{ trimPrefix "v" .Values.etcdCluster.image.tag }}
-  repository: {{ .Values.etcdCluster.image.repository }}:{{ .Values.etcdCluster.image.tag }}
+  repository: {{ .Values.etcdCluster.image.repository }}
   pod:
     busyboxImage: {{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}
 {{- if .Values.etcdCluster.podPriorityClassName }}


### PR DESCRIPTION
## Summary and Scope

Pulls in change that was in v7.0.1 but never made it to master
Fixes issue where image tag was duplicated causing IPBO when attempting to deploy etcd cluster using cray-service:~8

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5690](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5690)
* Change will also be needed in NA
* Future work required by  NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

mug

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

Verified that the issue started with cray-services 7.0.0 and was fixed in 7.0.1 but the change was never merged to master

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low
## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

