### PR TITLE
CASMPET-5692 master : Release cray-service v8.1.4 for 1.2.x

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [8.1.4]
+### Changed
+- Fix etcd issues with image tags and TLS
+- Enable TLS externally via cert-manager for postgresql
+
 ## [8.1.2]
 ### Changed
 - Updated pgbouncer image version to the latest (master-21) built from upstream

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 9.0.1
+version: 8.1.4
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:


### PR DESCRIPTION
## Summary and Scope
Set cray-services chart version to prepare for bug fix release, which includes fixes for 
* CASMPET-5689 : cray-services - tls errors on etcd cluster
* CASMPET-5690 : cray-services: ~8 missing change made to 7.0.1 for etcd image tag

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially Resolves [CASMPET-5692](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5692)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

vshasta

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

Tested install, upgrade and rollback of hbtd (etcd), spire (postgres) and gitea (postgres) when consuming the updated cray-service chart.

For the etcd cases, verified that the etcd clusters started up - no issues with tls or image tags
For the postgres cases, verified that the tls secret was created and mounted as /tls in the postgres pods
For example: postgres tls enabled case when tls is managed externally by cert-manager
```
$ kubectl get pod spire-postgres-0 -n spire -o json | jq -r '.spec.containers[] | select(.name=="postgres") | .volumeMounts'
[
  {
    "mountPath": "/home/postgres/pgdata",
    "name": "pgdata"
  },
  {
    "mountPath": "/dev/shm",
    "name": "dshm"
  },
  {
    "mountPath": "/tls",
    "name": "spire-postgres-tls"  <------
  },
  {
    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
    "name": "postgres-pod-token-qmq8s",
    "readOnly": true
  }
]
```
For example: postgres tls disabled case where tls is not managed thru the cert-manager secret
```
$ kubectl get pod spire-postgres-0 -n spire -o json | jq -r '.spec.containers[] | select(.name=="postgres") | .volumeMounts'
[
  {
    "mountPath": "/home/postgres/pgdata",
    "name": "pgdata"
  },
  {
    "mountPath": "/dev/shm",
    "name": "dshm"
  },
  {
    "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
    "name": "postgres-pod-token-qmq8s",
    "readOnly": true
  }
]
```

The `kubectl get postgresql -A` status generally changes from Running .. Updating .. UpdateFailed .. SyncFailed .. Running as the operator goes thru a few sync cycles to complete the 'Rolling update'. This generally took 5-7 min.

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
