### PR TITLE
CASMINST-147 Allow 127.0.0.6 non-TLS access

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [8.2.0]
+### Changed
+- Allow 127.0.0.6 access to postgres server without TLS. This provides access to
+  the Postgres server within the Istio Mesh without requiring an additional TLS
+  layer.
+
 ## [8.1.4]
 ### Changed
 - Fix etcd issues with image tags and TLS

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 8.1.4
+version: 8.2.0
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:

--- a/kubernetes/cray-service/templates/postgresql.yaml
+++ b/kubernetes/cray-service/templates/postgresql.yaml
@@ -102,6 +102,19 @@ spec:
     {{- end -}}
     {{- end }}
 
+  patroni:
+    pg_hba:
+    - local   all             all                             trust
+    - hostssl all             +zalandos    127.0.0.1/32       pam
+    - host    all             all          127.0.0.1/32       md5
+    - host    all             all          127.0.0.6/32       md5
+    - hostssl all             +zalandos    ::1/128            pam
+    - host    all             all          ::1/128            md5
+    - hostssl replication     standby      all                md5
+    - hostnossl all           all          all                reject
+    - hostssl all             +zalandos    all                pam
+    - hostssl all             all          all                md5
+
 {{- if .Values.sqlCluster.tls.enabled }}
 
   tls:


### PR DESCRIPTION
This allows 127.0.0.6 to connect to the postgres server without
starting a TLS connection. This is used by the istio-proxy for
connections within the istio mesh. These connections are already
encrypted.

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

