### PR TITLE
CASMPET-5877 Allow 127.0.0.6 non-TLS access

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [8.2.0]
+### Changed
+- Allow 127.0.0.6 access to postgres server without TLS. This provides access to
+  the Postgres server within the Istio Mesh without requiring an additional TLS
+  layer.
+
 ## [8.1.4]
 ### Changed
 - Fix etcd issues with image tags and TLS

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 8.1.4
+version: 8.2.0
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:

--- a/kubernetes/cray-service/templates/postgresql.yaml
+++ b/kubernetes/cray-service/templates/postgresql.yaml
@@ -102,6 +102,19 @@ spec:
     {{- end -}}
     {{- end }}
 
+  patroni:
+    pg_hba:
+    - local   all             all                             trust
+    - hostssl all             +zalandos    127.0.0.1/32       pam
+    - host    all             all          127.0.0.1/32       md5
+    - host    all             all          127.0.0.6/32       md5
+    - hostssl all             +zalandos    ::1/128            pam
+    - host    all             all          ::1/128            md5
+    - hostssl replication     standby      all                md5
+    - hostnossl all           all          all                reject
+    - hostssl all             +zalandos    all                pam
+    - hostssl all             all          all                md5
+
 {{- if .Values.sqlCluster.tls.enabled }}
 
   tls:


### PR DESCRIPTION


## Summary and Scope

This allows 127.0.0.6 to connect to the postgres server without
starting a TLS connection. This is used by the istio-proxy for
connections within the istio mesh. These connections are already
encrypted.


## Issues and Related PRs

* Resolves [CASMPET-5877](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5877)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated that gitea talked to postgres properly after updating its cray-service chart.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

