### PR TITLE
Add support for adding pod labels for deployments, daemonsets and statefulsets

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [8.2.1]
+### Changed
+- Add support for adding labels to pods for deployments, daemonsets and
+  statefulsets.
+
 ## [8.2.0]
 ### Changed
 - Allow 127.0.0.6 access to postgres server without TLS. This provides access to

--- a/kubernetes/cray-service/templates/_pod-labels.tpl
+++ b/kubernetes/cray-service/templates/_pod-labels.tpl
@@ -1,0 +1,10 @@
+{{/*
+Pod labels across the different types
+*/}}
+{{- define "cray-service.pod-labels" -}}
+{{ if .Values.podLabels -}}
+{{ with .Values.podLabels -}}
+{{ toYaml . -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/cray-service/templates/daemonset.yaml
+++ b/kubernetes/cray-service/templates/daemonset.yaml
@@ -41,6 +41,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "cray-service.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "cray-service.pod-labels" . | nindent 8 }}
       annotations:
         {{- include "cray-service.pod-annotations" . | nindent 8 }}
     spec:

--- a/kubernetes/cray-service/templates/deployment.yaml
+++ b/kubernetes/cray-service/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "cray-service.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "cray-service.pod-labels" . | nindent 8 }}
       annotations:
         {{- include "cray-service.pod-annotations" . | nindent 8 }}
     spec:

--- a/kubernetes/cray-service/templates/statefulset.yaml
+++ b/kubernetes/cray-service/templates/statefulset.yaml
@@ -43,6 +43,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "cray-service.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "cray-service.pod-labels" . | nindent 8 }}
       annotations:
         {{- include "cray-service.pod-annotations" . | nindent 8 }}
     spec:

--- a/kubernetes/cray-service/tests/deployment-pod-labels_test.yaml
+++ b/kubernetes/cray-service/tests/deployment-pod-labels_test.yaml
@@ -21,26 +21,24 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-apiVersion: v2
-name: cray-service
-version: 8.2.1
-description: This chart should never be installed directly, base your specific Cray service charts off this one
-home: https://github.com/Cray-HPE/base-charts
-maintainers:
-  - name: bklei
-  - name: kburns-hpe
-annotations:
-  artifacthub.io/images: |
-    - name: busybox
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox:1.28.0-glibc
-    - name: docker-kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
-    - name: coreos/etcd
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/coreos/etcd:v3.3.22
-    - name: postgres
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/postgres:13.2-alpine
-    - name: acid/pgbouncer
-      image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-21
-    - name: cray-postgres-db-backup
-      image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.1
-  artifacthub.io/license: MIT
+---
+suite: deployment test for pod labels
+templates:
+  - deployment.yaml
+tests:
+  - it: should render pod labels correctly
+    set:
+      podLabels:
+        one: 1
+        two: 2
+    asserts:
+      - template: deployment.yaml
+        documentIndex: 0
+        equal:
+          path: spec.template.metadata.labels.one
+          value: 1
+      - template: deployment.yaml
+        documentIndex: 0
+        equal:
+          path: spec.template.metadata.labels.two
+          value: 2

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -82,6 +82,8 @@ labels: {}
 annotations: {}
 # pod annotations only apply to spec.template.metadata.annotations within a deployment, statefulset, daemonset, etc.
 podAnnotations: {}
+# pod labels only apply to spec.template.metadata.labels within a deployment, statefulset, daemonset, etc.
+podLabels: {}
 # standard Kubernetes nodeSelector, tolerations, and affinity objects for spec
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
## Summary and Scope

Add ability to add pod labels for consumers of cray-service chart.

## Issues and Related PRs

* Resolves [CASMPET-5895](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5895)

## Testing

```
cray-service:
  podLabels:
    brad: is_cool
  type: Deployment
  nameOverride: cray-bos
```

```
spec:
  replicas: 3
  strategy:

    rollingUpdate:
      maxUnavailable: 50%
    type: RollingUpdate
  selector:
    matchLabels:
      app.kubernetes.io/name: cray-bos
      app.kubernetes.io/instance: RELEASE-NAME
  template:
    metadata:
      labels:
        app.kubernetes.io/name: cray-bos
        app.kubernetes.io/instance: RELEASE-NAME
        brad: is_cool                <---------- so true
      annotations:
--
kind: Deployment
```


### Tested on:

  * Local development environment

### Test description:

Rendered cray-bos template with changed base chart.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

