### PR TITLE
CASMPET-5873: change default tag of cray-postgres-db-backup for CVE fix

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [8.2.2]
+### Changed
+- The default tag for the cray-postgres-db-backup is now 0.2.2 to pick up security fixes.
+
 ## [8.2.1]
 ### Changed
 - Add support for adding labels to pods for deployments, daemonsets and

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 8.2.1
+version: 8.2.2
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:
@@ -42,5 +42,5 @@ annotations:
     - name: acid/pgbouncer
       image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-21
     - name: cray-postgres-db-backup
-      image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.1
+      image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.2
   artifacthub.io/license: MIT

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -308,7 +308,7 @@ sqlCluster:
     enabled: false
     image:
       repository: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup
-      tag: 0.2.1
+      tag: 0.2.2
       pullPolicy: IfNotPresent
 
     storageBucket: postgres-backup


### PR DESCRIPTION
## Summary and Scope

Change the default tag of cray-postgres-db-backup to 0.2.2 for CVE remediation. Bumped the base chart patch version.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially Resolves [CASMPET-5873](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5873)
* Future work required by [CASMPET-5873](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5873)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

Updated the spire chart to use the new base chart, made sure spire used the updated cray-postgres-db-backup image, and its db backup job completed with no errors.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

