### PR TITLE
Casmpet 5771

### DIFF
--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -1,0 +1,37 @@
+name: Run Pluto
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  pluto:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Dependency setup
+        run: |
+          set -x
+          sudo apt-get -y update
+          sudo apt-get install -y curl wget gnupg2 jq
+          source /etc/os-release
+          sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+          wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- | sudo apt-key add -
+          curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+          sudo apt-get install apt-transport-https --yes
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+          sudo apt-get update -qq -y
+          sudo apt-get -qq --yes install podman helm
+          plutover=$(curl --location --silent 'https://api.github.com/repos/FairwindsOps/pluto/releases/latest' | jq -r '.tag_name')
+          curl -sLo - https://github.com/FairwindsOps/pluto/releases/download/${plutover}/pluto_$(echo ${plutover} | tr -d v)_linux_amd64.tar.gz | tar -xvzf - pluto
+          sudo install -m755 pluto /usr/local/bin/pluto
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Render helm template charts for pluto to scan the generated resource api usage
+        run: |
+          helm template kubernetes/cray-service  --generate-name --dry-run --set sqlCluster.enabled=true --set sqlCluster.backup.enabled=true > cray-service.yaml
+          helm template kubernetes/cray-jobs  --generate-name --dry-run > cray-jobs.yaml
+      - name: Run pluto
+        run: |
+          pluto detect-files . | sort -u

--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [8.3.0]
+### Changed
+- Updated all api usage to no longer use removed Kubernetes apis.
+
 ## [8.2.3]
 ### Changed
 - The default tag for cray-postgres-db-backup is now 0.2.3 to fix a restore issue (CASMPET-5936).
@@ -86,7 +90,7 @@ All notable changes to this project will be documented in this file.
 
 ## [2.4.0]
 ### Changed
-- The statefulset template now includes the volumeClaimTemplate section, and the default values file is updated with a default case. This is used to create the pvc items for each replica. The pvs will be created using the specified storage class; if none is specified, the global value will be used, and if that is also not set, the default class will be used. 
+- The statefulset template now includes the volumeClaimTemplate section, and the default values file is updated with a default case. This is used to create the pvc items for each replica. The pvs will be created using the specified storage class; if none is specified, the global value will be used, and if that is also not set, the default class will be used.
 
 ## [2.1.0]
 ### Changed

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 8.2.3
+version: 8.3.0
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:

--- a/kubernetes/cray-service/templates/postgresql-backup.yaml
+++ b/kubernetes/cray-service/templates/postgresql-backup.yaml
@@ -61,7 +61,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "cray-service.postgresqlDbBackupFullname" . }}


### PR DESCRIPTION
## Summary and Scope

Removed usage of deprecated, and more importantly removed in k8s 1.22 api usage with batch/v1beta1 This is in preparation for k8s 1.22.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMPET-5771
* Change will also be needed in `<insert branch name here>`
* Future work required by anything in CASMPET-5770
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Validated the change manually on a 1.3 system by changing the resource manually and as per https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125

This beta api was basically subsumed by the non beta version so no further changes are needed in the definitions of the cronjob.

### Tested on:

  * redbull with a manual cronjob with/out the old and new api
  * Virtual Shasta

### Test description:

Mostly validated k8s 1.21 behaves the same way with the new cronjob and the old beta. As per the deprecation docs they behave the same.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? no
- Were continuous integration tests run? If not, why? n/a
- Was upgrade tested? If not, why? n/a
- Was downgrade tested? If not, why? n/a
- Were new tests (or test issues/Jiras) created for this change? I added a github action to run pluto against the setup so hopefully we don't get more deprecated api usage. Though there is one more certmanager api that we likely want to change.

## Risks and Mitigations

No known Risks

## Pull Request Checklist

- [x ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [x ] CHANGELOG.md updated
- [ x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

