### PR TITLE
CASMPET-5936: restore postgres from backup encountered errors

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,9 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [8.2.3]
+### Changed
+- The default tag for cray-postgres-db-backup is now 0.2.3 to fix a restore issue (CASMPET-5936).
+
 ## [8.2.2]
 ### Changed
-- The default tag for the cray-postgres-db-backup is now 0.2.2 to pick up security fixes.
+- The default tag for cray-postgres-db-backup is now 0.2.2 to pick up security fixes.
 
 ## [8.2.1]
 ### Changed

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 8.2.2
+version: 8.2.3
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:
@@ -42,5 +42,5 @@ annotations:
     - name: acid/pgbouncer
       image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-21
     - name: cray-postgres-db-backup
-      image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.2
+      image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3
   artifacthub.io/license: MIT

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -308,7 +308,7 @@ sqlCluster:
     enabled: false
     image:
       repository: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup
-      tag: 0.2.2
+      tag: 0.2.3
       pullPolicy: IfNotPresent
 
     storageBucket: postgres-backup


### PR DESCRIPTION
## Summary and Scope

Change the default tag of cray-postgres-db-backup to 0.2.3 to fix postgres sql version incompatibility causing restore to fail. Bumped the base chart patch version.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially Resolves [CASMPET-5936](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5936)
* Change will also be needed in `<insert branch name here>`
* Future work required by[CASMPET-5936](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5936)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
Verified that cray-keycloak chart can restore the backed up image successfully with the new image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

