### PR TITLE
CASMPET-6090 1.2.2 : Branch cray-services chart 7.0.1 version and add the postgres-db-backup fix

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [7.0.2]
+### Changed
+- The default tag for cray-postgres-db-backup is now 0.2.3 to fix a restore issue (CASMPET-5936).
+
 ## [7.0.01]
 ### Changed
 - cray-service renders EtcdCluster `spec.repository` values without tags

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-service
-version: 7.0.1
+version: 7.0.2
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:
@@ -20,5 +20,5 @@ annotations:
     - name: acid/pgbouncer
       image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-17
     - name: cray-postgres-db-backup
-      image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3
   artifacthub.io/license: MIT

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -283,7 +283,7 @@ sqlCluster:
     enabled: false
     image:
       repository: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup
-      tag: 0.2.0
+      tag: 0.2.3
       pullPolicy: IfNotPresent
 
     storageBucket: postgres-backup


### PR DESCRIPTION
## Summary and Scope

Branch cray-services chart 7.0.1 version and add the postgres-db-backup fix in cray-service chart 7.0.2

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix? bugfix

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6090](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6090)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

