### PR TITLE
Casmpet 6632 master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,12 @@ chart3:
 
 chart1_test:
 	helm lint "${CHART_PATH}/${CHART_NAME_1}"
-	docker run --rm -v ${PWD}/${CHART_PATH}:/apps ${HELM_UNITTEST_IMAGE} -3 ${CHART_NAME_1}
+	docker run --rm -v ${PWD}/${CHART_PATH}:/apps ${HELM_UNITTEST_IMAGE} ${CHART_NAME_1}
 
 chart2_test:
 	helm lint "${CHART_PATH}/${CHART_NAME_2}"
-	docker run --rm -v ${PWD}/${CHART_PATH}:/apps ${HELM_UNITTEST_IMAGE} -3 ${CHART_NAME_2}
+	docker run --rm -v ${PWD}/${CHART_PATH}:/apps ${HELM_UNITTEST_IMAGE} ${CHART_NAME_2}
 
 chart3_test:
 	helm lint "${CHART_PATH}/${CHART_NAME_3}"
-	docker run --rm -v ${PWD}/${CHART_PATH}:/apps ${HELM_UNITTEST_IMAGE} -3 ${CHART_NAME_3}
+	docker run --rm -v ${PWD}/${CHART_PATH}:/apps ${HELM_UNITTEST_IMAGE} ${CHART_NAME_3}

--- a/ct.yaml
+++ b/ct.yaml
@@ -24,4 +24,4 @@
 chart-dirs:
 - kubernetes
 additional-commands:
-  - helm unittest --helm3 --strict {{ .Path }}
+  - helm unittest --strict {{ .Path }}

--- a/kubernetes/cray-postgresql/tests/certificate_test.yaml
+++ b/kubernetes/cray-postgresql/tests/certificate_test.yaml
@@ -26,7 +26,7 @@ suite: certificate test
 templates:
   - certificate.yaml
 tests:
-  - it: should render 1 document 
+  - it: should render 1 document
     set:
       sqlCluster.enabled: true
       sqlCluster.tls.enabled: true

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 10.0.1
+version: 10.0.2
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:

--- a/kubernetes/cray-service/templates/_common-wait_for_job_container.tpl
+++ b/kubernetes/cray-service/templates/_common-wait_for_job_container.tpl
@@ -5,7 +5,7 @@ An InitContainer spec that waits for job completion
 - name: "{{.JobName }}"
   image: {{ .Root.Values.kubectl.image.repository }}:{{ .Root.Values.kubectl.image.tag }}
   imagePullPolicy: {{ .Root.Values.kubectl.image.pullPolicy }}
-  command: 
+  command:
     - /bin/sh
     - -c
     - |

--- a/kubernetes/cray-service/templates/postgresql.yaml
+++ b/kubernetes/cray-service/templates/postgresql.yaml
@@ -25,7 +25,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 {{- $root := . -}}
 {{- if .Values.sqlCluster.tls.enabled -}}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "{{ include "cray-service.fullname" $root }}-postgres-tls"
@@ -37,9 +37,10 @@ spec:
     - Cray
   commonName: "{{ include "cray-service.fullname" $root }}-postgres.{{ .Release.Namespace }}.cluster.svc"
   isCA: false
-  keySize: 2048
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  key:
+    algorithm: rsa
+    encoding: pkcs1
+    size: 2048
   usages:
     - server auth
     - client auth

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -187,7 +187,7 @@ service:
 # https://github.com/Cray-HPE/cray-etcd/tree/master/charts/cray-etcd-base
 #
 etcdWaitContainer: false
-  
+
 # A list of sealedSecrets passed in to be deployed.
 sealedSecrets: []
 # Whether or not to mount secrets as volumeMounts to containers


### PR DESCRIPTION
## Summary and Scope

Bumps cert-manager api in use for cray-services to use the v1 api. This is *NOT* backwards compatible with cert-manager 0.14.1. Will only work for csm 1.5+

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Tested on ashton by building this chart manually then building cray-spire and deploying it with this change and ensuring certs still work.

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

