### PR TITLE
CASMPET-6720 Add pooler resource customization

### DIFF
--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 8.2.3
+version: 8.2.4
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:

--- a/kubernetes/cray-service/templates/postgresql.yaml
+++ b/kubernetes/cray-service/templates/postgresql.yaml
@@ -91,6 +91,13 @@ spec:
     numberOfInstances: {{ .Values.sqlCluster.connectionPooler.instanceCount }}
     mode: "{{ .Values.sqlCluster.connectionPooler.mode }}"
     dockerImage: "{{ .Values.sqlCluster.connectionPooler.image }}"
+    resources:
+      requests:
+        cpu: "{{ .Values.sqlCluster.connectionPooler.resources.requests.cpu }}"
+        memory: "{{ .Values.sqlCluster.connectionPooler.resources.requests.memory }}"
+      limits:
+        cpu: "{{ .Values.sqlCluster.connectionPooler.resources.limits.cpu }}"
+        memory: "{{ .Values.sqlCluster.connectionPooler.resources.limits.memory }}"
   {{- end }}
 
   postgresql:

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -284,6 +284,13 @@ sqlCluster:
     instanceCount: 3
     mode: "session"
     image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-21
+    resources:
+      requests:
+        cpu: 500m
+        memory: 300Mi
+      limits:
+        cpu: 1
+        memory: 300Mi
   #
   # Consumers of this chart can override postgres cluster pod resource limits as follows:
   #


### PR DESCRIPTION
This adds the ability to use customizations.yaml to update the pooler resources. On larger systems the default memory setting is not enough. This also defaults it to 300Mi instead of 100Mi.