### PR TITLE
CASMPET-6720 Add pooler resource customization

### DIFF
--- a/kubernetes/cray-postgresql/Chart.yaml
+++ b/kubernetes/cray-postgresql/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.0.2
+version: 1.0.3
 name: cray-postgresql
 description: Cray-specific parent chart for PostgreSql
 keywords:

--- a/kubernetes/cray-postgresql/templates/postgresql.yaml
+++ b/kubernetes/cray-postgresql/templates/postgresql.yaml
@@ -67,6 +67,13 @@ spec:
     numberOfInstances: {{ .Values.sqlCluster.connectionPooler.instanceCount }}
     mode: "{{ .Values.sqlCluster.connectionPooler.mode }}"
     dockerImage: "{{ .Values.sqlCluster.connectionPooler.image }}"
+    resources:
+      requests:
+        cpu: "{{ .Values.sqlCluster.connectionPooler.resources.requests.cpu }}"
+        memory: "{{ .Values.sqlCluster.connectionPooler.resources.requests.memory }}"
+      limits:
+        cpu: "{{ .Values.sqlCluster.connectionPooler.resources.limits.cpu }}"
+        memory: "{{ .Values.sqlCluster.connectionPooler.resources.limits.memory }}"
   {{- end }}
 
   postgresql:

--- a/kubernetes/cray-postgresql/values.yaml
+++ b/kubernetes/cray-postgresql/values.yaml
@@ -47,6 +47,13 @@ sqlCluster:
     instanceCount: 3
     mode: "session"
     image: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer:master-21
+    resources:
+      requests:
+        cpu: 500m
+        memory: 300Mi
+      limits:
+        cpu: 1
+        memory: 300Mi
   #
   # Consumers of this chart can override postgres cluster pod resource limits as follows:
   #


### PR DESCRIPTION
This adds the ability to use customizations.yaml to update the pooler resources. On larger systems the default memory setting is not enough. This also defaults it to 300Mi instead of 100Mi.