### PR TITLE
CASMTRIAGE-6274: allow local replication by standby user

### DIFF
--- a/kubernetes/cray-postgresql/Chart.yaml
+++ b/kubernetes/cray-postgresql/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v2
-version: 1.0.3
+version: 1.0.4
 name: cray-postgresql
 description: Cray-specific parent chart for PostgreSql
 keywords:

--- a/kubernetes/cray-postgresql/templates/postgresql.yaml
+++ b/kubernetes/cray-postgresql/templates/postgresql.yaml
@@ -89,6 +89,7 @@ spec:
   patroni:
     pg_hba:
     - local   all             all                             trust
+    - local   replication     standby                         trust
     - hostssl all             +zalandos    127.0.0.1/32       pam
     - host    all             all          127.0.0.1/32       md5
     - host    all             all          127.0.0.6/32       md5

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 10.0.4
+version: 10.0.5
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:

--- a/kubernetes/cray-service/templates/postgresql.yaml
+++ b/kubernetes/cray-service/templates/postgresql.yaml
@@ -107,6 +107,7 @@ spec:
   patroni:
     pg_hba:
     - local   all             all                             trust
+    - local   replication     standby                         trust
     - hostssl all             +zalandos    127.0.0.1/32       pam
     - host    all             all          127.0.0.1/32       md5
     - host    all             all          127.0.0.6/32       md5


### PR DESCRIPTION
## Summary and Scope

During CSM 1.4 to 1.5 upgrade, we encountered an issue that the follower Postgres pod emitted the replication error from the local standby user. This PR fixes the issue by allowing the replication from the local standby user.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-6274](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6274)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `fanta`
  * `lemondrop`

### Test description:

Changed the postgresql pg_hba configuration, restarted the postgres statefulset, and verified that the log didn't contain the error anymore.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

