### PR TITLE
CASMPET-7127 pick up docker-kubectl:1.24.17 in base-charts

### DIFF
--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -34,7 +34,7 @@ annotations:
     - name: busybox
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox:1.28.0-glibc
     - name: docker-kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
     - name: postgres
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/postgres:13.2-alpine
     - name: acid/pgbouncer

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 10.0.5
+version: 10.0.6
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:

--- a/kubernetes/cray-service/tests/deployment-etcd-enabled_test.yaml
+++ b/kubernetes/cray-service/tests/deployment-etcd-enabled_test.yaml
@@ -49,7 +49,7 @@ tests:
       etcdWaitContainer: true
       chart.name: "test-chart"
       kubectl.image.repository: docker-kubectl
-      kubectl.image.tag: 1.19.9
+      kubectl.image.tag: 1.24.17
     asserts:
       - template: deployment.yaml
         equal:
@@ -58,7 +58,7 @@ tests:
       - template: deployment.yaml
         equal:
           path: spec.template.spec.initContainers[0].image
-          value: "docker-kubectl:1.19.9"
+          value: "docker-kubectl:1.24.17"
       - template: deployment.yaml
         equal:
           path: spec.template.spec.serviceAccountName

--- a/kubernetes/cray-service/values.yaml
+++ b/kubernetes/cray-service/values.yaml
@@ -53,7 +53,7 @@ busybox:
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    tag: 1.24.17
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary and Scope

Kubernetes is being upgraded to k8s 1.24 in CSM 1.6. Because of this, we should be using the docker-kubectl 1.24.17 container version. This PR picks up this container version in the cray-services chart.

## Issues and Related PRs

* Resolves [CASMPET-7127](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7127)

## Testing

I tested picking up this update cray-services chart in the cray-sts chart (cray-services is a dependent chart). I deployed the cray-sts chart successfully on Beau.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

