### PR TITLE
CASMPET-7212 update cray-service chart version to 11.0.0

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [11.0.0]
+### Changed
+- docker-kubectl container version updated to 1.24.17
+
 ## [10.0.0]
 ### Changed
 - Removed the trs worker template

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 10.0.6
+version: 11.0.0
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:


### PR DESCRIPTION
## Summary and Scope

I am going to be change the cray-service chart version to 11.0.0 and that version should be picked up in CSM 1.6. 
 
This will be the exact same chart as 10.0.6 so no more testing should be involved. It just has a different version number.
 
I am changing this version because many CSM 1.5 charts use cray-service version ~10.0 and are automatically picking up version 10.0.6. This is not desirable because that version should only be used on k8s 1.24 in CSM 1.6. To prevent this from happening, I am going to delete the cray-service 10.0.6 release and re-release with the version 11.0.0.

## Issues and Related PRs

* Resolves [CASMPET-7212](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7212)

## Testing

No testing done since this is just a version change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

