### PR TITLE
CASMPET-7250 update cray-service chart wait_for_job to succeed when SuccessCriteriaMet

### DIFF
--- a/kubernetes/cray-service/CHANGELOG.md
+++ b/kubernetes/cray-service/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [11.0.1]
+### Changed
+- change the wait_for_job_container to complete if 'SuccessCriteriaMet' job status. Needed for k8s 1.30
+
 ## [11.0.0]
 ### Changed
 - docker-kubectl container version updated to 1.24.17

--- a/kubernetes/cray-service/Chart.yaml
+++ b/kubernetes/cray-service/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-service
-version: 11.0.0
+version: 11.0.1
 description: This chart should never be installed directly, base your specific Cray service charts off this one
 home: https://github.com/Cray-HPE/base-charts
 maintainers:

--- a/kubernetes/cray-service/templates/_common-wait_for_job_container.tpl
+++ b/kubernetes/cray-service/templates/_common-wait_for_job_container.tpl
@@ -13,7 +13,7 @@ An InitContainer spec that waits for job completion
         JOB_CONDITION="$(kubectl get jobs -n services -l app.kubernetes.io/name={{ .JobName }} -o jsonpath='{.items[0].status.conditions[0].type}')"
         JOB_CONDITION_RC=$?
         if [ $JOB_CONDITION_RC -eq 0 ]; then
-          if [ "$JOB_CONDITION" == 'Complete' ]; then
+          if [ "$JOB_CONDITION" == 'Complete' -o "$JOB_CONDITION" == 'SuccessCriteriaMet' ]; then
             echo "Completed"
             break
           fi


### PR DESCRIPTION
## Summary and Scope

As of Kubernetes 1.30, a new JobConditionType of SuccessCriteriaMet has been added.  Currently all checks for completed jobs are checking for a type of Complete.  These all need to be updated to also check for SuccessCriteriaMet. This change can be made today in preparation for updating Kubernetes to 1.30+ in CSM 1.7.0.

## Issues and Related PRs

* Resolves [CASMPET-7250](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7250)

## Testing

### Tested on:

  * Beau

### Test description:

I did a simple test of the 'IF' statement syntax by creating a pod that uses the same docker-kubectl container image. The syntax of the IF statement works as expected in the container.

Logic inside the container is below.

```text
for each in fail Complete SuccessCriteriaMet fail2; do
  echo "testing: $each"
  JOB_CONDITION=$each
  if [ "$JOB_CONDITION" == 'Complete' -o "$JOB_CONDITION" == 'SuccessCriteriaMet' ]; then
    echo "TRUE"
  else
    echo "False"
  fi
done
```

The test output was

```bash
testing: fail
False
testing: Complete
TRUE
testing: SuccessCriteriaMet
TRUE
testing: fail2
False
```

## Risks and Mitigations

Low risk. This is backwards compatible which is why it is a patch version bump.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

